### PR TITLE
Add modification to make string-id compile with C++20

### DIFF
--- a/src/lib/sid/sid/sid.h
+++ b/src/lib/sid/sid/sid.h
@@ -45,14 +45,14 @@ class StringId
 
     StringId() : StringId(static_cast<Storage>(0)) { }
     explicit StringId(Storage data) : m_data(data) { }
-    explicit StringId::StringId(const char *str) : m_data(StringIdHash(str)) { }
+    explicit StringId(const char *str) : m_data(StringIdHash(str)) { }
 
-    static const StringId StringId::Concat(const StringId &sid, const char *str)
+    static const StringId Concat(const StringId &sid, const char *str)
     {
       return sid.Concat(str);
     }
 
-    const StringId StringId::Concat(const char *str) const
+    const StringId Concat(const char *str) const
     {
       return StringId(StringIdHashConcat(m_data, str));
     }


### PR DESCRIPTION
Note that in the current state of this PR, the unit tests are not compiling because `std::auto_ptr` used in one of CppUnit header, has been deprecated in C++17. If anyone wants to tackle this part, feel free to make the modification and push it to this branch.